### PR TITLE
Fix no audio on cold boot for rk817 clone boards (force Playback Path re-program)

### DIFF
--- a/files/ROOTFS/usr/local/bin/r36_config.sh
+++ b/files/ROOTFS/usr/local/bin/r36_config.sh
@@ -277,6 +277,12 @@ log "=== Starting ALSA audio configuration ==="
 
 CUR_ALSA_PATH=$(grep '^alsa_path[ \t]*=' "$CONFIG_FILE" | cut -d'=' -f2 | xargs || echo "$ALSA_PATH")
 log "Applying ALSA Playback Path: $CUR_ALSA_PATH"
+# rk817 clone boards (e.g. G80CA-MB) power up with 'Playback Path' already at the
+# target value, so re-setting the same value is a no-op: the codec never reprograms
+# the output route and there is NO audio on cold boot until a suspend/resume.
+# Force a real transition (OFF -> target) so the driver reprograms/enables the route.
+amixer -c 0 cset iface=MIXER,name='Playback Path' 'OFF' 2>>"$LOG_FILE" || true
+sleep 1
 amixer -c 0 cset iface=MIXER,name='Playback Path' "$CUR_ALSA_PATH" 2>>"$LOG_FILE" || log "WARNING: amixer Playback Path failed"
 
 OGAGE_SRC="$OGAGE_DIR/ogage.${CUR_ALSA_PATH}"


### PR DESCRIPTION
Problem

On a **cold boot there is no audio** (speaker or headphones, menu or emulators) on rk817 clone boards. A **suspend/resume** is currently the only workaround, and it lasts until the next cold boot.

- Board (`/proc/cpuinfo` Hardware): `G80CA-MB V1.3-20251212 Panel 8`, variant `clone`
- Codec: `rockchip,rk817-codec` (card 0, `ff070000.i2s-rk817-hifi`), ALSA only

### Root cause

`r36_config.sh` sets the output path on every boot with:

```sh
amixer -c 0 cset iface=MIXER,name='Playback Path' "$CUR_ALSA_PATH"   # SPK_HP
```

But these boards **power up with `Playback Path` already at `SPK_HP`**, so writing the *same* value is a **no-op**: the codec's output route is never (re)programmed and it stays silent until a suspend/resume forces a re-sync. `amixer contents` on a silent cold boot shows everything already looks correct, yet there is no sound:

```
numid=1 'Playback Path' items: OFF/SPK/HP/SPK_HP : values=3  (SPK_HP)
numid=3 'Playback Volume' 0..237                 : 232,232
numid=5 'Headphone Jack'                          : off
```

`alsa-restore.service` already runs `alsactl restore` at boot, so a plain state restore is not enough — what fixes it on resume is the codec being forced to reprogram the route.

### Fix

Force a **real transition** (`OFF` -> target) before the target path, so the driver actually reprograms/enables the output route.

### Testing

On my `G80CA-MB V1.3` (clone) unit, cold boot was silent until a suspend/resume. Running exactly this forced `OFF -> SPK_HP` transition restores speaker output on cold boot (verified on-device). It is harmless on boards that don't have the bug — it just re-asserts the same path.

Note: my on-device verification ran the toggle shortly after boot; here it is folded into `r36_config.sh`. The mechanism (updating the route before EmulationStation opens the PCM) should be equivalent. Happy to gate it to `variant = clone` or adjust placement/timing if you prefer.

### Scope

Likely affects other rk817 clone boards, not just `G80CA-MB V1.3`.