### PR TITLE
Copy resolution-matched logo and battery images in select_devices.sh

### DIFF
--- a/files/BOOT/dtb/select_devices.sh
+++ b/files/BOOT/dtb/select_devices.sh
@@ -297,7 +297,7 @@ resolution="${section_values["${chosen}__resolution"]:-}"
 logo_dir="$ROOT_DIR/dtb/logo"
 
 echo ""
-echo -e "${YELLOW}Applying boot logo for resolution: ${resolution:-unknown}${NC}"
+echo -e "${YELLOW}Applying boot images for resolution: ${resolution:-unknown}${NC}"
 
 if [[ -z "$resolution" ]]; then
     echo -e "${YELLOW}  No 'resolution' key for $chosen - leaving logo.bmp untouched${NC}"
@@ -310,6 +310,27 @@ else
         echo "  logo.bmp <- $(basename "$src_logo")"
     else
         echo -e "${YELLOW}  No logo-${resolution}.bmp - leaving logo.bmp untouched${NC}"
+    fi
+
+    # Battery images are resolution-specific too, and neither selector script
+    # installs them today. Archive names do not always match the resolution
+    # exactly (720x720 panels ship battery-720x270.zip), so fall back to width.
+    res_width="${resolution%%x*}"
+    src_batt="$logo_dir/battery-${resolution}.zip"
+    if [[ ! -f "$src_batt" ]]; then
+        src_batt="$(find "$logo_dir" -maxdepth 1 -type f -name "battery-${res_width}x*.zip" 2>/dev/null | head -n 1)"
+    fi
+
+    if [[ -n "$src_batt" && -f "$src_batt" ]]; then
+        if command -v unzip >/dev/null 2>&1; then
+            rm -f "$ROOT_DIR"/battery_*.bmp
+            unzip -o -q "$src_batt" -d "$ROOT_DIR/"
+            echo "  battery_*.bmp <- $(basename "$src_batt")"
+        else
+            echo -e "${YELLOW}  unzip unavailable - extract $(basename "$src_batt") to root manually${NC}"
+        fi
+    else
+        echo -e "${YELLOW}  No battery archive matching ${resolution} - skipping${NC}"
     fi
 fi
 

--- a/files/BOOT/dtb/select_devices.sh
+++ b/files/BOOT/dtb/select_devices.sh
@@ -289,11 +289,36 @@ else
     echo -e "${YELLOW}  No files were copied (source may be empty)${NC}"
 fi
  
+# -- Apply resolution-matched splash image --
+# Mirrors the behaviour already present in select_device.ps1, which picks the
+# logo from the device's `resolution` key. Built from the resolution string so
+# new panel sizes need no code change.
+resolution="${section_values["${chosen}__resolution"]:-}"
+logo_dir="$ROOT_DIR/dtb/logo"
+
+echo ""
+echo -e "${YELLOW}Applying boot logo for resolution: ${resolution:-unknown}${NC}"
+
+if [[ -z "$resolution" ]]; then
+    echo -e "${YELLOW}  No 'resolution' key for $chosen - leaving logo.bmp untouched${NC}"
+elif [[ ! -d "$logo_dir" ]]; then
+    echo -e "${YELLOW}  No dtb/logo folder found - skipping${NC}"
+else
+    src_logo="$logo_dir/logo-${resolution}.bmp"
+    if [[ -f "$src_logo" ]]; then
+        cp -f "$src_logo" "$ROOT_DIR/logo.bmp"
+        echo "  logo.bmp <- $(basename "$src_logo")"
+    else
+        echo -e "${YELLOW}  No logo-${resolution}.bmp - leaving logo.bmp untouched${NC}"
+    fi
+fi
+
 echo ""
 echo -e "${GREEN}==================================================${NC}"
 echo -e "${GREEN}   SUCCESS - DTB files updated for:${NC}"
 echo -e "${WHITE}   $chosen${NC}"
 echo -e "${WHITE}   Variant: $variant${NC}"
+echo -e "${WHITE}   Resolution: ${resolution:-unknown}${NC}"
 echo -e "${GREEN}==================================================${NC}"
 echo ""
  


### PR DESCRIPTION
## Problem

`select_devices.sh` copies the DTB pair for the selected device but never touches `logo.bmp`, so the boot partition keeps the default **640x480** splash regardless of which device was chosen.

On a 720x720 panel (e.g. `R36S Plus-V20 2025-03-18`) U-Boot then draws 640-pixel-wide rows into a 720-pixel-wide framebuffer. Every row lands 80px offset from the one above, and the splash appears sheared/scrambled for the first few seconds of boot, until the kernel loads the DTB and reinitialises the display.

**This is a parity gap, not a missing feature.** `select_device.ps1` already does the right thing — it reads the `resolution` key from `r36_devices.ini` and picks `logo-640x480.bmp` or `logo-720x720.bmp`. Only the shell selector is missing it, so Windows users get a correct splash while Mac/Linux users don't.

## Changes

**1. Copy resolution-matched boot logo** — brings `select_devices.sh` to parity with `select_device.ps1`.

The filename is built from the resolution string (`logo-${resolution}.bmp`) rather than hardcoding the two currently-known sizes, so adding a new panel resolution needs only the asset plus the `.ini` entry — no code change.

**2. Install resolution-matched battery images** — a genuine gap in *both* selectors.

`dtb/logo/` ships `battery-640x480.zip` and `battery-720x270.zip`, but neither script installs them, so the boot partition has no `battery_*.bmp` at all and U-Boot has nothing to draw for the charging / low-battery screens. Archive names don't always match the resolution exactly — the `720x270` archive actually contains 720x720 bitmaps — so this falls back to matching on width.

The two are split into separate commits in case you'd rather take only the parity fix.

## Safety

Both blocks are purely additive and guard before acting:

- no `resolution` key for the device → leaves the boot images untouched
- no `dtb/logo/` folder → skips
- no matching `logo-<res>.bmp` → leaves `logo.bmp` untouched
- no matching battery archive, or `unzip` unavailable → skips with a message

So no currently-working device can regress, including any that relies on the existing default.

## Testing

Verified on real hardware — an `R36S Plus-V20 2025-03-18` (batch 2551, 720x720) running `dArkOSRE_R36_trixie_04262026`.

Applying `logo-720x720.bmp` eliminated the scrambled boot splash entirely; the 720x720 battery set installed cleanly alongside it. Device identification was confirmed against `/boot/darkosre_device.log`, which reports `Hardware string: 'R36S Plus-V20 2025-03-18'` and `Resolution from devices.ini: 720x720`.

The added code was syntax-checked with `bash -n`.

## Known follow-up (not addressed here)

`select_devices.sh` requires **bash 4.2+** — it uses `declare -A` (line 44) and `[[ -v arr[key] ]]` (line 90). macOS ships bash 3.2, so the script can't run at all there:

```
select_devices.sh: line 44: declare: -A: invalid option
select_devices.sh: line 90: syntax error near `grouped_devices["$v"]'
```

The wiki points Mac users at this script, so in practice they currently have to place DTBs by hand. That's a larger rewrite and out of scope for this PR, but I'm happy to open a separate one if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
