### PR TITLE
Add SPK/HP audio toggle scripts for V04 boards

### DIFF
--- a/files/ROOTFS/audio-hp.sh
+++ b/files/ROOTFS/audio-hp.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# /usr/local/bin/audio-hp.sh
+# Forca a saida de audio para HEADPHONE (HP), ignorando o estado anterior.
+
+STATE_FILE="/var/local/audio_path"
+CARD=0
+
+# Cria a pasta de estado automaticamente, se ainda nao existir
+sudo mkdir -p /var/local
+
+echo "=== Ativando saida: HEADPHONE (HP) ==="
+
+amixer -c $CARD sset 'Playback Path' HP > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+    echo "Erro: nao consegui trocar 'Playback Path' para HP"
+    exit 1
+fi
+
+# Salva o estado, pra o audio-reinit.sh saber qual usar apos reboot/resume
+echo "HP" | sudo tee "$STATE_FILE" > /dev/null
+
+# Volume audivel, mic mutado
+amixer -c $CARD sset 'Playback' 237 > /dev/null 2>&1
+amixer -c $CARD sset 'Record' 0 > /dev/null 2>&1
+
+# Persiste no ALSA state
+sudo alsactl store 0 2>/dev/null
+
+# Som de confirmacao
+TEST_SOUND="/usr/share/sounds/alsa/Front_Center.wav"
+if [ -f "$TEST_SOUND" ]; then
+    aplay "$TEST_SOUND" > /dev/null 2>&1
+fi
+
+echo "=== Audio agora em: HP ==="

--- a/files/ROOTFS/audio-speaker.sh
+++ b/files/ROOTFS/audio-speaker.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# /usr/local/bin/audio-speaker.sh
+# Forca a saida de audio para SPEAKER (SPK), ignorando o estado anterior.
+
+STATE_FILE="/var/local/audio_path"
+CARD=0
+
+# Cria a pasta de estado automaticamente, se ainda nao existir
+sudo mkdir -p /var/local
+
+echo "=== Ativando saida: SPEAKER (SPK) ==="
+
+amixer -c $CARD sset 'Playback Path' SPK > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+    echo "Erro: nao consegui trocar 'Playback Path' para SPK"
+    exit 1
+fi
+
+# Salva o estado, pra o audio-reinit.sh saber qual usar apos reboot/resume
+echo "SPK" | sudo tee "$STATE_FILE" > /dev/null
+
+# Volume audivel, mic mutado
+amixer -c $CARD sset 'Playback' 237 > /dev/null 2>&1
+amixer -c $CARD sset 'Record' 0 > /dev/null 2>&1
+
+# Persiste no ALSA state
+sudo alsactl store 0 2>/dev/null
+
+# Som de confirmacao
+TEST_SOUND="/usr/share/sounds/alsa/Front_Center.wav"
+if [ -f "$TEST_SOUND" ]; then
+    aplay "$TEST_SOUND" > /dev/null 2>&1
+fi
+
+echo "=== Audio agora em: SPK ==="

--- a/files/ROOTFS/audio-toggle.sh
+++ b/files/ROOTFS/audio-toggle.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# /usr/local/bin/audio-toggle.sh
+# Alterna entre saida de Speaker (SPK) e Headphone (HP) no codec RK817.
+# Salva o estado atual em um arquivo pra o audio-reinit.sh saber qual usar
+# depois de um boot ou de um resume (tela apagar/acordar).
+
+STATE_FILE="/var/local/audio_path"
+CARD=0
+
+# Cria a pasta de estado automaticamente, se ainda nao existir
+sudo mkdir -p /var/local
+
+# Le o estado salvo, ou assume SPK se nao existir ainda
+if [ -f "$STATE_FILE" ]; then
+    CURRENT=$(cat "$STATE_FILE")
+else
+    CURRENT="SPK"
+fi
+
+# Decide o proximo estado
+if [ "$CURRENT" = "SPK" ]; then
+    NEXT="HP"
+else
+    NEXT="SPK"
+fi
+
+echo "=== Trocando audio: $CURRENT -> $NEXT ==="
+
+# Aplica o novo path
+amixer -c $CARD sset 'Playback Path' "$NEXT" > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+    echo "Erro: nao consegui trocar 'Playback Path' para $NEXT"
+    exit 1
+fi
+
+# Salva o novo estado
+echo "$NEXT" | sudo tee "$STATE_FILE" > /dev/null
+
+# Garante volume audivel e mic mutado (ajuste os valores se quiser)
+amixer -c $CARD sset 'Playback' 237 > /dev/null 2>&1
+amixer -c $CARD sset 'Record' 0 > /dev/null 2>&1
+
+# Persiste no ALSA state tambem, pra sobreviver a reboot
+sudo alsactl store 0 2>/dev/null
+
+# Toca um som curto de confirmacao
+TEST_SOUND="/usr/share/sounds/alsa/Front_Center.wav"
+if [ -f "$TEST_SOUND" ]; then
+    aplay "$TEST_SOUND" > /dev/null 2>&1
+fi
+
+echo "=== Audio agora em: $NEXT ==="


### PR DESCRIPTION
Adds three shell scripts to control audio output routing:
- audio-hp.sh: forces output to headphone
- audio-speaker.sh: forces output to speaker
- audio-toggle.sh: toggles between HP/SPK based on last saved state

Fixes simultaneous SPK+HP output caused by DTB mismatch on Y3506_V04_20250523 boards (tested with Panel 5 / HL-MP35HD-B-V5 aftermarket display). State persists via alsactl store to /var/local/audio_path.

Originally released at:
https://github.com/HunterSoul5/dArkOSRE-R36/releases/tag/v1.0-audio-fix